### PR TITLE
call trim() on key for cookie (android)

### DIFF
--- a/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
+++ b/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
@@ -63,7 +63,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
             String[] cookies = cookieList.get(0).split(";");
             for (int i = 0; i < cookies.length; i++) {
                 String[] cookie = cookies[i].split("=");
-                map.putString(cookie[0], cookie[1]);
+                map.putString(cookie[0].trim(), cookie[1]);
             }
         }
         callback.invoke(null, map);

--- a/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
+++ b/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
@@ -63,7 +63,9 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
             String[] cookies = cookieList.get(0).split(";");
             for (int i = 0; i < cookies.length; i++) {
                 String[] cookie = cookies[i].split("=");
-                map.putString(cookie[0].trim(), cookie[1]);
+                if(cookie.length > 1) {
+                  map.putString(cookie[0].trim(), cookie[1]);
+                }
             }
         }
         callback.invoke(null, map);


### PR DESCRIPTION
it seems like `get` method on android returns result like below

```
{ 
  ' _session_id': 'somesessionid',
  ' remember_me_token': 'sometoken'
}
```

there is a useless whitespace on head of cookie key and when I call `res.remember_me_token` returns `undefined` but you can call `res[' remember_me_token']` returns value.

so I `trim()` ed it, but I'm new to Java and android so any suggestions help me.