### PR TITLE
Android split cookie name:value only on first instance of =

### DIFF
--- a/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
+++ b/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
@@ -62,7 +62,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
         if (cookieList != null) {
             String[] cookies = cookieList.get(0).split(";");
             for (int i = 0; i < cookies.length; i++) {
-                String[] cookie = cookies[i].split("=");
+                String[] cookie = cookies[i].split("=", 2);
                 if(cookie.length > 1) {
                   map.putString(cookie[0].trim(), cookie[1]);
                 }


### PR DESCRIPTION
Currently the cookie string (e.g. cookieName=value) will be split on every instance of = and only the first two items will be used.  This adds support for cookies with '=' in their value.