### PR TITLE
Upgrade build tools to 25.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This is generally a good idea. I did it specifically because the latest [Android Gradle plugin 2.3.0](https://developer.android.com/studio/releases/gradle-plugin.html) only supports build tools versions >=25.