### PR TITLE
Remove override of 'createJSModules' for RN 0.47 (#64)

### DIFF
--- a/android/src/main/java/com/psykar/cookiemanager/CookieManagerPackage.java
+++ b/android/src/main/java/com/psykar/cookiemanager/CookieManagerPackage.java
@@ -24,7 +24,7 @@ public class CookieManagerPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
https://github.com/facebook/react-native/releases/tag/v0.47.0

This is not a breaking change for this library. Users can continue to update `react-native-cookies` without being forced to update RN to >= 0.47. The downside to doing it this way instead of removing it is that there is now dead code for RN >= 0.47.

Fixes #64 