### PR TITLE
Add webkit-support for the methods: get, set, getAll, clearAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,64 @@ CookieManager.clearByName('cookie_name')
 
 ```
 
+#### WebKit-Support (iOS only)
+React Native comes with a WebView component, which uses UIWebView on iOS. Introduced in iOS 8 Apple implemented the WebKit-Support with all the performance boost. 
+
+To use this it's required to use a special implementation of the WebView component (e.g. [react-native-wkwebview](https://github.com/CRAlpha/react-native-wkwebview)).
+
+This special implementation of the WebView component stores the cookies __not__ in `NSHTTPCookieStorage` anymore. The new cookie-storage is `WKHTTPCookieStore` and implementes a differnt interface.
+
+To use this _CookieManager_ with WebKit-Support we extended the interface with the attribute `useWebKit` (a boolean value, default: `FASLE`) for the following methods:
+
+|Method|WebKit-Support|Method-Signature|
+|---|---|---|
+|getAll| Yes | `CookieManager.getAll(useWebKit:boolean)` |
+|clearAll| Yes | `CookieManager.clearAll(useWebKit:boolean)` |
+|get| Yes | `CookieManager.get(url:string, useWebKit:boolean)` |
+|set| Yes | `CookieManager.set(cookie:object, useWebKit:boolean)` |
+
+##### Usage
+```javascript
+import CookieManager from 'react-native-cookies';
+
+const useWebKit = true;
+
+// list cookies (IOS ONLY)
+CookieManager.getAll(useWebKit)
+	.then((res) => {
+		console.log('CookieManager.getAll from webkit-view =>', res);
+	});
+
+// clear cookies
+CookieManager.clearAll(useWebKit)
+	.then((res) => {
+		console.log('CookieManager.clearAll from webkit-view =>', res);
+	});
+
+// Get cookies as a request header string
+CookieManager.get('http://example.com', useWebKit)
+	.then((res) => {
+		console.log('CookieManager.get from webkit-view =>', res);
+		// => 'user_session=abcdefg; path=/;'
+	});
+
+// set a cookie (IOS ONLY)
+const newCookie: = {
+	name: 'myCookie',
+	value: 'myValue',
+	domain: 'some domain',
+	origin: 'some origin',
+	path: '/',
+	version: '1',
+	expiration: '2015-05-30T12:30:00.00-05:00'
+};
+
+CookieManager.set(newCookie, useWebKit)
+	.then((res) => {
+		console.log('CookieManager.set from webkit-view =>', res);
+	});
+```
+
 ### TODO
 
 - Proper `getAll` dictionary by domain

--- a/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
+++ b/android/src/main/java/com/psykar/cookiemanager/CookieManagerModule.java
@@ -33,7 +33,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void set(ReadableMap cookie, final Promise promise) throws Exception {
+    public void set(ReadableMap cookie, boolean useWebKit, final Promise promise) throws Exception {
         throw new Exception("Cannot call on android, try setFromResponse");
     }
 
@@ -53,12 +53,12 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getAll(Promise promise) throws Exception {
+    public void getAll(boolean useWebKit, Promise promise) throws Exception {
         throw new Exception("Cannot get all cookies on android, try getCookieHeader(url)");
     }
 
     @ReactMethod
-    public void get(String url, Promise promise) throws URISyntaxException, IOException {
+    public void get(String url, boolean useWebKit, Promise promise) throws URISyntaxException, IOException {
         URI uri = new URI(url);
 
         Map<String, List<String>> cookieMap = this.cookieHandler.get(uri, new HashMap());
@@ -78,7 +78,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void clearAll(final Promise promise) {
+    public void clearAll(boolean useWebKit, final Promise promise) {
         this.cookieHandler.clearCookies(new Callback() {
             public void invoke(Object... args) {
                 promise.resolve(null);

--- a/index.js
+++ b/index.js
@@ -19,16 +19,18 @@ if (Platform.OS === 'ios') {
 }
 
 const functions = [
-    'set',
     'setFromResponse',
     'getFromResponse',
-    'get',
-    'getAll',
-    'clearAll',
     'clearByName'
 ];
 
-module.exports = {}
+module.exports = {
+  getAll: (useWebKit = false) => CookieManager.getAll(useWebKit),
+  clearAll: (useWebKit = false) => CookieManager.clearAll(useWebKit),
+  get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
+  set: (cookie, useWebKit = false) => CookieManager.set(cookie, useWebKit),
+};
+
 for (var i = 0; i < functions.length; i++) {
     module.exports[functions[i]] = CookieManager[functions[i]];
 }

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.h
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.h
@@ -5,6 +5,8 @@
 #import <React/RCTBridgeModule.h>
 #endif
 
+#import <WebKit/WebKit.h>
+
 @interface RNCookieManagerIOS : NSObject <RCTBridgeModule>
 
 @end


### PR DESCRIPTION
Hi all,

for my own project I have to manage the cookies of the webKit-WebView (https://github.com/CRAlpha/react-native-wkwebview). With this PR I provide a first and naive implementation of a WebKit-Support for the methods `get()`, `set()`, `getAll()`, `clearAll()`.

I wanted to make changes as small as possible and no or only minimale changes at the API. 

I hope this changes are Ok and helpful for you?