### PR TITLE
set version string to a tag that exists

### DIFF
--- a/ios/react-native-cookies.podspec
+++ b/ios/react-native-cookies.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
 
 Pod::Spec.new do |s|
   s.name                = package['name']
-  s.version             = "1.0.2"
+  s.version             = "3.2.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS


### PR DESCRIPTION
Currently the podspec version is set to 1.0.2, which causes Cocoapods to look for a tag by the name "v1.0.2". This tag doesn't exist on the github repo, so the install fails. This PR updates that version string to "3.2.0" which is the latest release.