### PR TITLE
Update gradle and Android SDK versions for React Native 0.56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,15 +4,15 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
React Native 0.56 has new dependencies for Gradle and the Android SDK.