### PR TITLE
Fixing subdomain issues #114

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -128,13 +128,7 @@ RCT_EXPORT_METHOD(
     } else {
         NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
         for (NSHTTPCookie *c in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url]) {
-            NSMutableDictionary *d = [NSMutableDictionary dictionary];
-            [d setObject:c.value forKey:@"value"];
-            [d setObject:c.name forKey:@"name"];
-            [d setObject:c.domain forKey:@"domain"];
-            [d setObject:c.path forKey:@"path"];
-            [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
-            [cookies setObject:d forKey:c.name];
+            [cookies setObject:c.value forKey:c.name];
         }
         resolve(cookies);
     }


### PR DESCRIPTION
I test if the domain of the cookie match the host url. So, for the url `foo.bar.com` : 
 - `bar.com` will match
 - `barfoo.foo.bar.com` will not match
 - `foo.bar.com` will match

It fix the issue #114 

We still have to handle the situation where we have 2 cookies : 
```
const cookie1 = {
  domain: "foo.bar.com",
  name: "session",
  path:"/",
  value: "6de9c6965c1465ed"
};

const cookie2 = {
  domain: "bar.com",
  name: "session",
  path:"/",
  value: "a1784ef82bc"
};
```
Then the code is non determistic.

It is only for the webkit version