### PR TITLE
fix(docs): gradle compile config depreciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ project(':react-native-cookies').projectDir = new File(rootProject.projectDir, '
 ```gradle
 dependencies {
    ...
-   compile project(':react-native-cookies')
+   implementation project(':react-native-cookies')
 }
 ```
 


### PR DESCRIPTION
PR facebook/react-native#20767 bumped the version of the Android
Gradle Plugin to v3 which uses the newer Gradle dependency
configurations `implementation` and `api` which make `compile`
obsolete.

PR facebook/react-native#20853 covered the `link` command.

Using `compile` will result in a warning message during app build and
`compile` will be eventually removed by Gradle.