### PR TITLE
remove unused getAll with arity 2 from RCT_EXPORT_METHOD

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -230,21 +230,6 @@ RCT_EXPORT_METHOD(
     }
 }
 
-RCT_EXPORT_METHOD(getAll:(RCTPromiseResolveBlock)resolve
-    rejecter:(RCTPromiseRejectBlock)reject) {
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
-    for (NSHTTPCookie *c in cookieStorage.cookies) {
-        NSMutableDictionary *d = [NSMutableDictionary dictionary];
-        [d setObject:c.value forKey:@"value"];
-        [d setObject:c.name forKey:@"name"];
-        [d setObject:c.domain forKey:@"domain"];
-        [d setObject:c.path forKey:@"path"];
-        [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
-        [cookies setObject:d forKey:c.name];
-    }
-}
-
 -(NSDictionary *)createCookieList:(NSArray<NSHTTPCookie *>*)cookies
 {
     NSMutableDictionary *cookieList = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Hello. Currently if I try to call `CookieManager.getAll()` it will throw exception complaining the arity difference between native and js code. 
I am not too familiar with object-c and react bridge code but I belive the function I remove from this PR is not needed anymore and it solve the exception when calling `getAll`.
Please let me know if there is any problem so I can further imrpove it.