### PR TITLE
iOS fixes + cleanup

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -220,21 +220,6 @@ RCT_EXPORT_METHOD(
     }
 }
 
-RCT_EXPORT_METHOD(getAll:(RCTPromiseResolveBlock)resolve
-    rejecter:(RCTPromiseRejectBlock)reject) {
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
-    for (NSHTTPCookie *c in cookieStorage.cookies) {
-        NSMutableDictionary *d = [NSMutableDictionary dictionary];
-        [d setObject:c.value forKey:@"value"];
-        [d setObject:c.name forKey:@"name"];
-        [d setObject:c.domain forKey:@"domain"];
-        [d setObject:c.path forKey:@"path"];
-        [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
-        [cookies setObject:d forKey:c.name];
-    }
-}
-
 -(NSDictionary *)createCookieList:(NSArray<NSHTTPCookie *>*)cookies
 {
     NSMutableDictionary *cookieList = [NSMutableDictionary dictionary];

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -145,17 +145,7 @@ RCT_EXPORT_METHOD(
             reject(@"", NOT_AVAILABLE_ERROR_MESSAGE, nil);
         }
     } else {
-        NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
-        for (NSHTTPCookie *c in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url]) {
-            NSMutableDictionary *d = [NSMutableDictionary dictionary];
-            [d setObject:c.value forKey:@"value"];
-            [d setObject:c.name forKey:@"name"];
-            [d setObject:c.domain forKey:@"domain"];
-            [d setObject:c.path forKey:@"path"];
-            [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
-            [cookies setObject:d forKey:c.name];
-        }
-        resolve(cookies);
+        resolve([self createCookieList:[[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url]]);
     }
 }
 

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -237,6 +237,11 @@ RCT_EXPORT_METHOD(
     [cookieData setObject:cookie.name forKey:@"name"];
     [cookieData setObject:cookie.domain forKey:@"domain"];
     [cookieData setObject:cookie.path forKey:@"path"];
+
+    if (cookie.expiresDate) {
+        [cookieData setObject:[self.formatter stringFromDate:cookie.expiresDate] forKey:@"expiresDate"];
+    }
+
     return cookieData;
 }
 


### PR DESCRIPTION
The duplicated `getAll` method was causing the React Native bridge to fail when it couldn't resolve which target to use.

This also cleans up cookie list generation to use the helper that already existed (`createCookieList`) and adds (optional) expiration date formatting to it.